### PR TITLE
Merging NoteLayoutFeature onto Master

### DIFF
--- a/app/src/main/java/com/example/fbuteamproject/layouts/NoteLayout.java
+++ b/app/src/main/java/com/example/fbuteamproject/layouts/NoteLayout.java
@@ -1,0 +1,33 @@
+package com.example.fbuteamproject.layouts;
+
+import com.google.ar.sceneform.Node;
+import com.google.ar.sceneform.math.Vector3;
+import com.google.ar.sceneform.rendering.ViewRenderable;
+
+public class NoteLayout extends Node {
+
+    private static final float NOTE_HEIGHT = 0.75f;
+    private static final Vector3 NOTE_LOCATION_VECTOR = new Vector3(0.0f, 0.4f, 0.0f);
+    private static final Vector3 NOTE_SCALE_VECTOR = new Vector3(NOTE_HEIGHT * 2, NOTE_HEIGHT * 1.5f, 1.0f);
+    private Node noteNode;
+
+    public NoteLayout(){
+        this.noteNode = new Node();
+    }
+
+    public NoteLayout(ViewRenderable noteRenderable){
+
+        this.noteNode = new Node();
+
+        createVideoNode(noteRenderable);
+
+    }
+
+    public void createVideoNode(ViewRenderable noteRenderable) {
+        noteNode.setParent(this);
+        noteNode.setRenderable(noteRenderable);
+        noteNode.setLocalScale(NOTE_LOCATION_VECTOR);
+        noteNode.setLocalScale(NOTE_SCALE_VECTOR);
+
+    }
+}

--- a/app/src/main/java/com/example/fbuteamproject/layouts/VideoLayout.java
+++ b/app/src/main/java/com/example/fbuteamproject/layouts/VideoLayout.java
@@ -16,15 +16,19 @@ public class VideoLayout extends Node {
     private static final Vector3 VIDEO_SCALE_VECTOR = new Vector3(VIDEO_HEIGHT * 2, VIDEO_HEIGHT, 1.0f);
     private Node videoNode;
 
+    public VideoLayout(){
+        this.videoNode = new Node();
+    }
+
     public VideoLayout(ModelRenderable videoRenderable){
 
-        videoNode = new Node();
+        this.videoNode = new Node();
 
         createVideoNode(videoRenderable);
 
     }
 
-    private void createVideoNode(ModelRenderable videoRenderable) {
+    public void createVideoNode(ModelRenderable videoRenderable) {
         videoNode.setParent(this);
         videoNode.setRenderable(videoRenderable);
         videoNode.setLocalScale(VIDEO_LOCATION_VECTOR);


### PR DESCRIPTION
- Created NoteLayout Class that simply organizes the Note in AR
-- All it needs is a ViewRenderable that represents the Note; the rest of the creation and organization is handled by the Class

*Also created Default Constructors for both the NoteLayout and VideoLayout Classes and made the create methods public so that the Layouts can have the Models and Views be imported when needed instead of at creation